### PR TITLE
Use continue 2 to skip from switch

### DIFF
--- a/lib/Doctrine/Query/Tokenizer.php
+++ b/lib/Doctrine/Query/Tokenizer.php
@@ -93,7 +93,7 @@ class Doctrine_Query_Tokenizer
                 break;
 
                 case 'by':
-                    break 2;
+                    continue 2;
 
                 default:
                     if ( ! isset($p)) {


### PR DESCRIPTION
- 'continue;' - identical to 'break;' in switch; if switch is wrapped inside foreach loop then likely intended behaviour has been skipping to the next iteration of outside loop instead (hence the warning in PHP 7.3);
- 'break 2;' - breaks both looping structures (switch and foreach) immediately;
- 'continue 2;' - moves to the next iteration of the outside looping structure (foreach);