### PR TITLE
fix Serializable deprecation warnings ; return types

### DIFF
--- a/lib/Doctrine/Access.php
+++ b/lib/Doctrine/Access.php
@@ -100,7 +100,7 @@ abstract class Doctrine_Access extends Doctrine_Locator_Injectable implements Ar
      * @param   mixed $offset
      * @return  boolean Whether or not this object contains $offset
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return $this->contains($offset);
     }
@@ -112,6 +112,7 @@ abstract class Doctrine_Access extends Doctrine_Locator_Injectable implements Ar
      * @param   mixed $offset
      * @return  mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         // array notation with no index was causing 'undefined variable: $offset' notices in php7,
@@ -131,6 +132,7 @@ abstract class Doctrine_Access extends Doctrine_Locator_Injectable implements Ar
      * @param   mixed $value
      * @return  void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if ( ! isset($offset)) {
@@ -146,6 +148,7 @@ abstract class Doctrine_Access extends Doctrine_Locator_Injectable implements Ar
      * @see   set, offsetSet, __set
      * @param mixed $offset
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         return $this->remove($offset);

--- a/lib/Doctrine/Collection.php
+++ b/lib/Doctrine/Collection.php
@@ -147,7 +147,7 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
      *
      * @return array
      */
-    public function serialize()
+    public function __serialize()
     {
         $vars = get_object_vars($this);
 
@@ -160,7 +160,12 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
 
         $vars['_table'] = $vars['_table']->getComponentName();
 
-        return serialize($vars);
+        return $vars;
+    }
+
+    public function serialize()
+    {
+        return serialize($this->__serialize());
     }
 
     /**
@@ -168,12 +173,10 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
      *
      * @return void
      */
-    public function unserialize($serialized)
+    public function __unserialize($array)
     {
         $manager    = Doctrine_Manager::getInstance();
         $connection    = $manager->getCurrentConnection();
-
-        $array = unserialize($serialized);
 
         foreach ($array as $name => $values) {
             $this->$name = $values;
@@ -189,6 +192,11 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
         if ($keyColumn !== null) {
             $this->keyColumn = $keyColumn;
         }
+    }
+
+    public function unserialize($str)
+    {
+        return $this->__unserialize(unserialize($str));
     }
 
     /**
@@ -432,7 +440,7 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
      *
      * @return integer
      */
-    public function count()
+    public function count(): int
     {
         return count($this->data);
     }
@@ -1036,6 +1044,7 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
      *
      * @return Iterator
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         $data = $this->data;

--- a/lib/Doctrine/Connection.php
+++ b/lib/Doctrine/Connection.php
@@ -1178,7 +1178,7 @@ abstract class Doctrine_Connection extends Doctrine_Configurable implements Coun
      *
      * @return ArrayIterator        SPL ArrayIterator object
      */
-    public function getIterator()
+    public function getIterator(): ArrayIterator
     {
         return new ArrayIterator($this->tables);
     }
@@ -1188,7 +1188,7 @@ abstract class Doctrine_Connection extends Doctrine_Configurable implements Coun
      *
      * @return integer
      */
-    public function count()
+    public function count(): int
     {
         return $this->_count;
     }
@@ -1611,12 +1611,17 @@ abstract class Doctrine_Connection extends Doctrine_Configurable implements Coun
      *
      * @return string $serialized
      */
-    public function serialize()
+    public function __serialize()
     {
         $vars = get_object_vars($this);
         $vars['dbh'] = null;
         $vars['isConnected'] = false;
-        return serialize($vars);
+        return $vars;
+    }
+
+    public function serialize()
+    {
+        return serialize($this->__serialize());
     }
 
     /**
@@ -1625,13 +1630,16 @@ abstract class Doctrine_Connection extends Doctrine_Configurable implements Coun
      * @param string $serialized
      * @return void
      */
-    public function unserialize($serialized)
+    public function __unserialize($array)
     {
-        $array = unserialize($serialized);
-
         foreach ($array as $name => $values) {
             $this->$name = $values;
         }
+    }
+
+    public function unserialize($str)
+    {
+        return $this->__unserialize(unserialize($str));
     }
 
     /**

--- a/lib/Doctrine/Formatter.php
+++ b/lib/Doctrine/Formatter.php
@@ -270,6 +270,6 @@ class Doctrine_Formatter extends Doctrine_Connection_Module
     public function getTableName($table)
     {
         $format = $this->conn->getAttribute(Doctrine_Core::ATTR_TBLNAME_FORMAT);
-        return sprintf($format, str_replace(sprintf($format, null), null, $table));
+        return sprintf($format, str_replace(sprintf($format, null), '', $table));
     }
 }

--- a/lib/Doctrine/Manager.php
+++ b/lib/Doctrine/Manager.php
@@ -638,7 +638,7 @@ class Doctrine_Manager extends Doctrine_Configurable implements Countable, Itera
      *
      * @return integer
      */
-    public function count()
+    public function count(): int
     {
         return count($this->_connections);
     }
@@ -648,7 +648,7 @@ class Doctrine_Manager extends Doctrine_Configurable implements Countable, Itera
      *
      * @return ArrayIterator
      */
-    public function getIterator()
+    public function getIterator(): ArrayIterator
     {
         return new ArrayIterator($this->_connections);
     }

--- a/lib/Doctrine/Query.php
+++ b/lib/Doctrine/Query.php
@@ -2134,7 +2134,7 @@ class Doctrine_Query extends Doctrine_Query_Abstract implements Countable
      * @param array $params        an array of prepared statement parameters
      * @return integer             the count of this query
      */
-    public function count($params = array())
+    public function count($params = array()): int
     {
         $q = $this->getCountSqlQuery();
         $params = $this->getCountQueryParams($params);

--- a/lib/Doctrine/Record/Iterator.php
+++ b/lib/Doctrine/Record/Iterator.php
@@ -68,6 +68,7 @@ class Doctrine_Record_Iterator extends ArrayIterator
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         $value = parent::current();

--- a/lib/Doctrine/Relation.php
+++ b/lib/Doctrine/Relation.php
@@ -169,11 +169,12 @@ abstract class Doctrine_Relation implements ArrayAccess
         return $this->definition['equal'];
     }
 
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->definition[$offset]);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         if (isset($this->definition[$offset])) {
@@ -183,6 +184,7 @@ abstract class Doctrine_Relation implements ArrayAccess
         return null;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (isset($this->definition[$offset])) {
@@ -190,6 +192,7 @@ abstract class Doctrine_Relation implements ArrayAccess
         }
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         $this->definition[$offset] = false;

--- a/lib/Doctrine/Table.php
+++ b/lib/Doctrine/Table.php
@@ -1133,7 +1133,7 @@ class Doctrine_Table extends Doctrine_Configurable implements Countable, Seriali
         }
 
         if ( ! is_array($orderBy)) {
-            $e1 = explode(',', $orderBy);
+            $e1 = explode(',', $orderBy ?? '');
         } else {
             $e1 = $orderBy;
         }

--- a/lib/Doctrine/Table.php
+++ b/lib/Doctrine/Table.php
@@ -1977,7 +1977,7 @@ class Doctrine_Table extends Doctrine_Configurable implements Countable, Seriali
      *
      * @return integer number of records in the table
      */
-    public function count()
+    public function count(): int
     {
         return $this->createQuery()->count();
     }
@@ -2983,12 +2983,12 @@ class Doctrine_Table extends Doctrine_Configurable implements Countable, Seriali
         throw new Doctrine_Table_Exception(sprintf('Unknown method %s::%s', get_class($this), $method));
     }
 
-    public function serialize()
+    public function __serialize()
     {
         $options = $this->_options;
         unset($options['declaringClass']);
 
-        return serialize(array(
+        return [
             $this->_identifier,
             $this->_identifierType,
             $this->_columns,
@@ -3000,13 +3000,16 @@ class Doctrine_Table extends Doctrine_Configurable implements Countable, Seriali
             $options,
             $this->_invokedMethods,
             $this->_useIdentityMap,
-        ));
+        ];
     }
 
-    public function unserialize($data)
+    public function serialize()
     {
-        $all = unserialize($data);
+        return serialize($this->__serialize());
+    }
 
+    public function __unserialize($all)
+    {
         $this->_identifier = $all[0];
         $this->_identifierType = $all[1];
         $this->_columns = $all[2];
@@ -3018,6 +3021,11 @@ class Doctrine_Table extends Doctrine_Configurable implements Countable, Seriali
         $this->_options = $all[8];
         $this->_invokedMethods = $all[9];
         $this->_useIdentityMap = $all[10];
+    }
+
+    public function unserialize($str)
+    {
+        return $this->__unserialize(unserialize($str));
     }
 
     public function initializeFromCache(Doctrine_Connection $conn)

--- a/lib/Doctrine/Table/Repository.php
+++ b/lib/Doctrine/Table/Repository.php
@@ -102,7 +102,7 @@ class Doctrine_Table_Repository implements Countable, IteratorAggregate
      * Doctrine_Registry implements interface Countable
      * @return integer                      the number of records this registry has
      */
-    public function count()
+    public function count(): int
     {
         return count($this->registry);
     }
@@ -138,7 +138,7 @@ class Doctrine_Table_Repository implements Countable, IteratorAggregate
      * getIterator
      * @return ArrayIterator
      */
-    public function getIterator()
+    public function getIterator(): ArrayIterator
     {
         return new ArrayIterator($this->registry);
     }

--- a/lib/Doctrine/Validator.php
+++ b/lib/Doctrine/Validator.php
@@ -97,7 +97,7 @@ class Doctrine_Validator extends Doctrine_Locator_Injectable
         } else if ($type == 'array' || $type == 'object') {
             $length = strlen(serialize($value));
         } else if ($type == 'decimal' || $type == 'float') {
-            $value = abs($value);
+            $value = abs(floatval($value));
 
             $localeInfo = localeconv();
             $decimalPoint = $localeInfo['mon_decimal_point'] ? $localeInfo['mon_decimal_point'] : $localeInfo['decimal_point'];
@@ -111,7 +111,7 @@ class Doctrine_Validator extends Doctrine_Locator_Injectable
         } else if ($type == 'blob') {
             $length = strlen($value);
         } else {
-            $length = self::getStringLength($value);
+            $length = self::getStringLength((string)$value);
         }
         if ($length > $maximumLength) {
             return false;
@@ -125,7 +125,7 @@ class Doctrine_Validator extends Doctrine_Locator_Injectable
      * @param string $string 
      * @return integer $length
      */
-    public static function getStringLength($string)
+    public static function getStringLength(string $string)
     {
         if (function_exists('mb_strlen')) {
             return mb_strlen($string, 'utf8');

--- a/lib/Doctrine/Validator/ErrorStack.php
+++ b/lib/Doctrine/Validator/ErrorStack.php
@@ -149,7 +149,7 @@ class Doctrine_Validator_ErrorStack extends Doctrine_Access implements Countable
      *
      * @return ArrayIterator unknown
      */
-    public function getIterator()
+    public function getIterator(): ArrayIterator
     {
         return new ArrayIterator($this->_errors);
     }
@@ -164,7 +164,7 @@ class Doctrine_Validator_ErrorStack extends Doctrine_Access implements Countable
      *
      * @return integer
      */
-    public function count()
+    public function count(): int
     {
         return count($this->_errors);
     }

--- a/lib/Doctrine/Validator/Exception.php
+++ b/lib/Doctrine/Validator/Exception.php
@@ -51,12 +51,12 @@ class Doctrine_Validator_Exception extends Doctrine_Exception implements Countab
         return $this->invalid;
     }
 
-    public function getIterator()
+    public function getIterator(): ArrayIterator
     {
         return new ArrayIterator($this->invalid);
     }
 
-    public function count()
+    public function count(): int
     {
         return count($this->invalid);
     }


### PR DESCRIPTION
This is to supress some of the warnings and notices that arise with upgrading PHP up to 8.1